### PR TITLE
update spark application status by sidecar container lifecycle management

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -804,6 +804,8 @@ func (c *Controller) syncSparkApplication(key string) error {
 			c.recordSparkApplicationEvent(appCopy)
 		}
 	case v1beta2.CompletedState, v1beta2.FailedState, v1beta2.KilledState:
+		// Delete the driver pod and optional UI resources (Service/Ingress) created for the application.
+		c.handleSparkApplicationDeletion(app)
 		if c.hasApplicationExpired(app) {
 			glog.Infof("Garbage collecting expired SparkApplication %s/%s", app.Namespace, app.Name)
 			err := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(app.Name, metav1.NewDeleteOptions(0))

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -393,15 +393,14 @@ func (c *Controller) getAndUpdateDriverState(app *v1beta2.SparkApplication) erro
 	app.Status.SparkApplicationID = getSparkApplicationID(driverPod)
 	driverState := podStatusToDriverState(driverPod.Status)
 
-	// reuse executor state as driver pod state
-	app.Status.DriverInfo.PodState = string(podPhaseToExecutorState(driverPod.Status.Phase))
+	app.Status.DriverInfo.PodState = string(driverState)
 	app.Status.DriverInfo.PodIp = driverPod.Status.PodIP
 	// add creationTimestamp
 	if app.Status.DriverInfo.CreationTimestamp.IsZero() {
 		app.Status.DriverInfo.CreationTimestamp = driverPod.CreationTimestamp
 	}
 
-	if driverPod.Status.Phase == apiv1.PodSucceeded || driverPod.Status.Phase == apiv1.PodFailed {
+	if hasDriverTerminated(driverState) {
 		if app.Status.TerminationTime.IsZero() || app.Status.DriverInfo.TerminationTime.IsZero() {
 			now := metav1.Now()
 			app.Status.TerminationTime = now
@@ -444,7 +443,7 @@ func isExecutorDone(state string) bool {
 func isDriverDone(driverInfo v1beta2.DriverInfo) bool {
 	if driverInfo.PodName != "" &&
 		!driverInfo.TerminationTime.IsZero() &&
-		(driverInfo.PodState == string(v1beta2.ExecutorFailedState) || driverInfo.PodState == string(v1beta2.ExecutorCompletedState)) {
+		(driverInfo.PodState == string(v1beta2.DriverFailedState) || driverInfo.PodState == string(v1beta2.DriverCompletedState)) {
 		return true
 	}
 	return false


### PR DESCRIPTION
update app.Status.DriverInfo by driverState  

### Before
```go
func podPhaseToExecutorState(podPhase apiv1.PodPhase) v1beta2.ExecutorState {
	switch podPhase {
	case apiv1.PodPending:
		return v1beta2.ExecutorPendingState
	case apiv1.PodRunning:
		return v1beta2.ExecutorRunningState
	case apiv1.PodSucceeded:
		return v1beta2.ExecutorCompletedState
	case apiv1.PodFailed:
		return v1beta2.ExecutorFailedState
	default:
		return v1beta2.ExecutorUnknownState
	}
}
```
`app.Status.DriverInfo.PodState` doesn't take sidecar container state into account.
### After
```go
func podStatusToDriverState(podStatus apiv1.PodStatus) v1beta2.DriverState {
	switch podStatus.Phase {
	case apiv1.PodPending:
		return v1beta2.DriverPendingState
	case apiv1.PodRunning:
		state := getDriverContainerTerminatedState(podStatus)
		if state != nil {
			if state.ExitCode == 0 {
				return v1beta2.DriverCompletedState
			}
			return v1beta2.DriverFailedState
		}
		return v1beta2.DriverRunningState
	case apiv1.PodSucceeded:
		return v1beta2.DriverCompletedState
	case apiv1.PodFailed:
		state := getDriverContainerTerminatedState(podStatus)
		if state != nil && state.ExitCode == 0 {
			return v1beta2.DriverCompletedState
		}
		return v1beta2.DriverFailedState
	default:
		return v1beta2.DriverUnknownState
	}
}
```
`app.Status.DriverInfo.PodState` reuses `driverState` which updated by `podStatusToDriverState` method. And it takes sidecar container status into account.