### PR TITLE
update spark application status by sidecar container lifecycle management

### DIFF
--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -786,6 +786,8 @@ func (c *Controller) syncSparkApplication(key string) error {
 			c.recordSparkApplicationEvent(appCopy)
 		}
 	case v1beta2.CompletedState, v1beta2.FailedState, v1beta2.KilledState:
+		// Delete the driver pod and optional UI resources (Service/Ingress) created for the application.
+		c.handleSparkApplicationDeletion(app)
 		if c.hasApplicationExpired(app) {
 			glog.Infof("Garbage collecting expired SparkApplication %s/%s", app.Namespace, app.Name)
 			err := c.crdClient.SparkoperatorV1beta2().SparkApplications(app.Namespace).Delete(app.Name, metav1.NewDeleteOptions(0))


### PR DESCRIPTION
update app.Status.DriverInfo by driverState

### Before
```go
func podPhaseToExecutorState(podPhase apiv1.PodPhase) v1beta2.ExecutorState {
	switch podPhase {
	case apiv1.PodPending:
		return v1beta2.ExecutorPendingState
	case apiv1.PodRunning:
		return v1beta2.ExecutorRunningState
	case apiv1.PodSucceeded:
		return v1beta2.ExecutorCompletedState
	case apiv1.PodFailed:
		return v1beta2.ExecutorFailedState
	default:
		return v1beta2.ExecutorUnknownState
	}
}
```
`app.Status.DriverInfo.PodState` doesn't take sidecar container state into account.

### After
```go
func podStatusToDriverState(podStatus apiv1.PodStatus) v1beta2.DriverState {
	switch podStatus.Phase {
	case apiv1.PodPending:
		return v1beta2.DriverPendingState
	case apiv1.PodRunning:
		state := getDriverContainerTerminatedState(podStatus)
		if state != nil {
			if state.ExitCode == 0 {
				return v1beta2.DriverCompletedState
			}
			return v1beta2.DriverFailedState
		}
		return v1beta2.DriverRunningState
	case apiv1.PodSucceeded:
		return v1beta2.DriverCompletedState
	case apiv1.PodFailed:
		state := getDriverContainerTerminatedState(podStatus)
		if state != nil && state.ExitCode == 0 {
			return v1beta2.DriverCompletedState
		}
		return v1beta2.DriverFailedState
	default:
		return v1beta2.DriverUnknownState
	}
}
```
`app.Status.DriverInfo.PodState` reuses driverState which updated by `podStatusToDriverState` method. And it takes sidecar container status into account.